### PR TITLE
fix(dependabot): configure GitHub Packages npm registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,16 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.DEPENDABOT_NPM_PKG_TOKEN}}
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    registries:
+      - npm-github
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Problem

Dependabot security update jobs (e.g. the `fast-xml-parser` advisory) fail before running with:

```
private_registry_config_not_found | { "source": "npm.pkg.github.com" }
```

This is **not** caused by anything in this repo — all dependencies resolve from `registry.npmjs.org`, and there is no `.npmrc`. The failure comes from the server-side `automatic-github-packages-auth` experiment injecting an `npm.pkg.github.com` credential into the job, which the updater then can't resolve because no registry config exists.

## Fix

Declare the GitHub Packages npm registry explicitly in `dependabot.yml` so the lookup succeeds.

## Required follow-up (manual, one-time)

This change only works once a Dependabot secret exists:

- **Settings → Secrets and variables → Dependabot → New repository secret**
- Name: `DEPENDABOT_NPM_PKG_TOKEN`
- Value: a classic PAT with the **`read:packages`** scope

After the secret is added, re-trigger a failed run (e.g. comment `@dependabot recreate` on an affected PR).