### PR TITLE
fix(dependabot): scope GitHub Packages registry to @bxcodec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     token: ${{secrets.DEPENDABOT_NPM_PKG_TOKEN}}
+    scope: "@bxcodec"
 updates:
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Problem

Every Dependabot run since 2026-07-26 has failed. Latest run [`31946892575`](../../actions/runs/31946892575):

```
updater | ERROR Error during file fetching; aborting: Private npm registries require
either a .npmrc file in your repository, or explicit `scope`/`replaces-base`
configuration in dependabot.yml. Registry: npm.pkg.github.com
```

29 Dependabot alerts are open and none of them can be acted on while jobs abort this early.

## Cause

The registry block added in #226 fixed `private_registry_config_not_found` but replaced it with this. The job now receives the credential:

```json
"credentials-metadata":[{"type":"git_source","host":"github.com"},
                        {"type":"npm_registry","registry":"npm.pkg.github.com"}]
```

…with no `scope`, no `replaces-base`, and no `.npmrc` in the repo. The updater has a credential for a non-default registry and no rule saying which packages belong to it, so it aborts during file fetching — before `package.json` is ever read.

Worth noting the repo consumes **nothing** from GitHub Packages: `package-lock.json` has 0 references to `npm.pkg.github.com` and every dependency resolves to `registry.npmjs.org`. The credential exists only because the server-side `automatic-github-packages-auth` experiment injects it.

## Fix

Scope the registry to `@bxcodec`, so it applies only to packages under that scope — of which there are none. The credential becomes well-defined and inert, and resolution of every real dependency stays on npmjs.

`DEPENDABOT_NPM_PKG_TOKEN` is already configured as a Dependabot secret, so no secret changes are needed.

## Verification

`scope` is the key the updater's own error message names, though it is absent from the documented key list for `npm-registry` in the dependabot.yml reference. If it is rejected as an unknown key, the fallback is `replaces-base: false` in the same position. Either outcome is visible on the next update run.